### PR TITLE
Fix CI by installing package in editable mode

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,4 +24,5 @@ jobs:
         pip install pytest
     - name: Test with pytest
       run: |
-        pytest
+        chmod +x run_tests.sh
+        ./run_tests.sh

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+export PYTHONPATH=$PYTHONPATH:.
 pip install -e .
 pytest

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export PYTHONPATH=.
+pip install -e .
 pytest


### PR DESCRIPTION
This commit fixes the CI error by:
- Modifying the `run_tests.sh` script to install the package in editable mode (`pip install -e .`) before running the tests.
- Modifying the GitHub Actions workflow to use the `run_tests.sh` script to run the tests.