### PR TITLE
Refactor resonance detection to use ResonanceDetector, optimize JS workers, and add pytest.ini

### DIFF
--- a/modalWorker.js
+++ b/modalWorker.js
@@ -2,18 +2,30 @@ onmessage = (e) => {
   const { nodes = [], edges = [], stiffnessScale = 1, massScale = 1 } = e.data;
   const nModes = 10;
   let totalL = 0;
-  for (const [a, b] of edges) {
-    const dx = nodes[a].x - nodes[b].x;
-    const dy = nodes[a].y - nodes[b].y;
-    const dz = nodes[a].z - nodes[b].z;
+
+  const flatNodes =
+    nodes instanceof Float32Array || nodes instanceof Float64Array
+      ? nodes
+      : Float32Array.from(nodes.flatMap((node) => [node.x, node.y, node.z]));
+
+  for (let i = 0; i < edges.length; i++) {
+    const a = edges[i][0] * 3;
+    const b = edges[i][1] * 3;
+
+    const dx = flatNodes[a] - flatNodes[b];
+    const dy = flatNodes[a + 1] - flatNodes[b + 1];
+    const dz = flatNodes[a + 2] - flatNodes[b + 2];
     totalL += Math.hypot(dx, dy, dz);
   }
+
   const geomFactor = Math.max(0.1, totalL / Math.max(1, edges.length));
   const base = (35 * Math.sqrt(stiffnessScale / Math.max(0.01, massScale))) / geomFactor;
   const modes = [];
+
   for (let i = 1; i <= nModes; i++) {
     const freq = base * i * (1 + Math.sin(i * 0.73) * 0.07);
     modes.push({ mode: i, frequency: Number(freq.toFixed(2)) });
   }
+
   postMessage({ type: 'done', modes });
 };

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-export PYTHONPATH=$PYTHONPATH:.
 pip install -e .
 python -m pytest


### PR DESCRIPTION
### Motivation
- Remove duplicated FFT/math code in `analysis.py` by centralizing resonance logic in the optimized `ResonanceDetector` module. 
- Speed up browser-side computation by switching worker hot loops to flat typed-array indexing and avoiding object property lookups. 
- Make pytest discovery robust so tests run without needing `PYTHONPATH` exports.

### Description
- Replaced raw FFT/wavelet math in `drr_framework/analysis.py` with delegation to `self.resonance_detector.detect(...)` and mapped its outputs into the framework shape (`frequencies`, `power`, `dominant_freq`).
- Removed unnecessary `scipy.fft` imports from `analysis.py` now that detection is delegated.
- Updated `modalWorker.js` to accept or convert `nodes` into a flat `Float32Array/Float64Array` and use indexed `for` loops and flat indexing (`[x,y,z,...]`) for distance computations and mode generation.
- Updated `structuralWorker.js` to use the same flat typed-array conversion and direct indexing in fixed-node detection, stiffness assembly, CG multiply, and stress post-processing loops to reduce per-iteration overhead.
- Added `pytest.ini` with `pythonpath = .` and `testpaths = tests` to eliminate the need for `export PYTHONPATH=.` during test runs and simplified `run_tests.sh` accordingly.

### Testing
- Ran `python -m pytest` at repository root and all tests passed: 17 passed (no failures).
- Verified coverage-relevant tests including `tests/test_fft_optimization.py` and `tests/test_resonance_detector_accuracy.py` executed and succeeded under the new code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699939c1f1c08332a8743e34d2f03726)