### PR TITLE
Implement Morlet wavelet resonance detection and improve analysis API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Morlet wavelet resonance detection (`method="wavelet"`): an FFT-based
+  continuous wavelet transform with peak selection on the global wavelet
+  spectrum, parabolic peak refinement, and a returned `scalogram` and
+  `time_axis` that localize resonances in time for nonstationary signals
+- `analyze_system` accepts `method` and `peak_height_ratio`, so Welch or
+  wavelet detection can be used end to end instead of always falling back to
+  FFT
+- `RealTimeDRR` accepts `analysis_interval` to run the full analysis every
+  N-th point on high-frequency streams (default 1 keeps existing behavior)
+- `plot_results` accepts `show=False` for headless or batch environments
+  (the figure is closed after optional saving instead of displayed)
+
 ### Changed
 - Vectorized lagged-correlation rooting scores (one cross-correlation matrix per
   lag instead of a `corrcoef` call per variable pair), speeding up
@@ -22,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call, so repeated analyses on one instance produce identical belief states
 - `DynamicResonanceRooting` validates `embedding_dim`, `tau`, and
   `sampling_rate` at construction
+- The Heston benchmark now always uses `numpy.random.default_rng` with
+  pre-drawn correlated shocks instead of the legacy global NumPy RNG when no
+  seed is given (seeded draws are still deterministic, but differ from
+  previous versions)
 
 ### Fixed
 - `MarkovChain` stationary distribution had the wrong length when eigenvalue 1
@@ -30,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `QBistAgent.reset()` now restores the prior belief instead of only clearing
   the history
 - `RealTimeDRR.reset()` also resets the anomaly detector history
+- `drr_framework.__version__` reported a stale `0.2.0`; it is now
+  single-sourced from the installed package metadata (`4.2.0`)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The **Dynamic Resonance Rooting (DRR) Framework** is a computational pipeline th
 2. **Rooting Analysis** — What are the directional lead-lag relationships between variables?
 3. **Stability Assessment** — How stable are the resonance structures over time?
 
-DRR combines spectral analysis (FFT, Welch PSD), causal rooting (transfer entropy, lagged correlation), and state-space diagnostics to provide evidence for hypothesis generation about system behavior.
+DRR combines spectral analysis (FFT, Welch PSD, Morlet wavelet scalograms), causal rooting (transfer entropy, lagged correlation), and state-space diagnostics to provide evidence for hypothesis generation about system behavior.
 
 ---
 
@@ -43,7 +43,7 @@ DRR combines spectral analysis (FFT, Welch PSD), causal rooting (transfer entrop
 
 | Capability | Description |
 |------------|-------------|
-| **Resonance Detection** | Identifies oscillatory patterns via FFT and Welch power spectral density |
+| **Resonance Detection** | Identifies oscillatory patterns via FFT, Welch power spectral density, or Morlet wavelet scalograms (time-localized, for nonstationary signals) |
 | **Causal Rooting** | Maps directional lead-lag relationships using transfer entropy or lagged correlation |
 | **Resonance Depth** | Composite scoring combining spectral concentration, temporal persistence, phase coherence, and amplitude stability |
 | **State-Space Diagnostics** | Transition, measurement, and stability analysis |

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,13 +18,15 @@ Important methods:
 - `time_delay_embedding(data)`: build Takens-style delayed coordinates for a
   one-dimensional signal.
 - `detect_resonances(data, method="fft", peak_height_ratio=0.1)`: detect
-  dominant frequencies per dimension.
+  dominant frequencies per dimension. `method` accepts `"fft"`, `"welch"`,
+  `"wavelet"`, or `"markov"`.
 - `calculate_resonance_depths(window_size=100)`: compute scalar depth values and
   store component details.
 - `analyze_influence_network()`: build a directed NetworkX graph from rooting
   scores for multivariate data.
-- `analyze_system(data, multivariate=False, window_size=100, state_space=True)`: run
-  the end-to-end DRR workflow.
+- `analyze_system(data, multivariate=False, window_size=100, state_space=True,
+  method="fft", peak_height_ratio=0.1)`: run the end-to-end DRR workflow with
+  the chosen spectral method.
 
 ## Resonance Modules
 
@@ -43,6 +45,18 @@ result = ResonanceDetector().detect(
 
 Returns method name, dominant frequencies, peak magnitudes, confidence estimates,
 noise floor, frequency axis, and spectrum.
+
+Supported methods:
+
+- `"fft"`: single FFT magnitude spectrum.
+- `"welch"`: Welch-averaged power spectral density (lower variance).
+- `"wavelet"`: Morlet continuous wavelet transform. Peaks are selected from the
+  time-averaged global wavelet spectrum, and the result additionally includes a
+  `scalogram` (frequency x time power map) and `time_axis` for nonstationary
+  signals. For very long inputs the scalogram is omitted (`None`) to bound
+  memory; the spectrum and peaks are still returned.
+- `"markov"`: KMeans state clustering with transition-matrix persistence
+  analysis (returns a different, state-based schema).
 
 ### `DepthCalculator`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,9 +45,12 @@ flowchart TD
     Center --> Method{Detection method}
     Method --> FFT[FFT spectrum]
     Method --> Welch[Welch PSD]
+    Method --> Wavelet[Morlet wavelet scalogram]
     Method --> Markov[Discrete Markov states]
     FFT --> Peaks[Peak selection]
     Welch --> Peaks
+    Wavelet --> Global[Global wavelet spectrum]
+    Global --> Peaks
     Markov --> Persistent[Persistent state detection]
     Peaks --> Confidence[Noise-floor confidence estimate]
     Persistent --> Result[Resonance result]

--- a/src/drr_framework/__init__.py
+++ b/src/drr_framework/__init__.py
@@ -86,7 +86,18 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__version__ = "0.2.0"
+# Version is single-sourced from the installed package metadata (pyproject.toml).
+try:
+    from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+    from importlib.metadata import version as _package_version
+
+    try:
+        __version__ = _package_version("drr-framework")
+    except _PackageNotFoundError:
+        __version__ = "4.2.0"
+except ImportError:  # pragma: no cover - Python < 3.8
+    __version__ = "4.2.0"
+
 __author__ = "Christopher Woodyard"
 __email__ = "ciao_chris@example.com"
 

--- a/src/drr_framework/analysis.py
+++ b/src/drr_framework/analysis.py
@@ -100,7 +100,8 @@ class DynamicResonanceRooting:
 
         Args:
             data (np.ndarray): Time series data (1D or multivariate)
-            method (str): Method for spectral analysis ('fft', 'welch', or 'markov')
+            method (str): Method for spectral analysis
+                ('fft', 'welch', 'wavelet', or 'markov')
             peak_height_ratio (float): Ratio of max power for peak detection
 
         Returns:
@@ -241,6 +242,8 @@ class DynamicResonanceRooting:
         window_size: int = 100,
         state_space: bool = True,
         state_space_horizon: int = 12,
+        method: str = "fft",
+        peak_height_ratio: float = 0.1,
     ) -> Dict[str, object]:
         """
         Perform complete DRR analysis on system data.
@@ -251,6 +254,9 @@ class DynamicResonanceRooting:
             window_size (int): Window size for depth calculation
             state_space (bool): Whether to attach DSGE-inspired state-space diagnostics
             state_space_horizon (int): Horizon for impulse-response diagnostics
+            method (str): Spectral method for resonance detection
+                ('fft', 'welch', 'wavelet', or 'markov')
+            peak_height_ratio (float): Ratio of max power for peak detection
 
         Returns:
             Dict: Complete analysis results
@@ -260,7 +266,9 @@ class DynamicResonanceRooting:
         try:
             # Step 1: Detect resonances
             logger.info("Detecting resonances...")
-            resonances = self.detect_resonances(data)
+            resonances = self.detect_resonances(
+                data, method=method, peak_height_ratio=peak_height_ratio
+            )
             results["resonances"] = resonances
 
             # Step 2: Calculate resonance depths
@@ -303,7 +311,9 @@ class DynamicResonanceRooting:
             logger.exception("Error in system analysis")
             raise
 
-    def plot_results(self, results: Dict, data: np.ndarray, save_plots: bool = False):
+    def plot_results(
+        self, results: Dict, data: np.ndarray, save_plots: bool = False, show: bool = True
+    ):
         """
         Create comprehensive visualization of DRR analysis results.
 
@@ -311,6 +321,8 @@ class DynamicResonanceRooting:
             results (Dict): Analysis results from analyze_system
             data (np.ndarray): Original input data
             save_plots (bool): Whether to save plots to files
+            show (bool): Whether to display the figure; pass False in headless
+                or batch environments (the figure is closed after saving)
         """
         if not results:
             logger.warning("No results to plot")
@@ -482,7 +494,10 @@ class DynamicResonanceRooting:
             plt.savefig("drr_analysis_results.png", dpi=300, bbox_inches="tight")
             logger.info("Plot saved as 'drr_analysis_results.png'")
 
-        plt.show()
+        if show:
+            plt.show()
+        else:
+            plt.close(fig)
 
 
 # Make the class available for import

--- a/src/drr_framework/benchmarks.py
+++ b/src/drr_framework/benchmarks.py
@@ -55,7 +55,7 @@ class BenchmarkSystems:
 
         logger.info("Generating Heston benchmark data")
         state = initial_state or {"s0": 100, "v0": 0.04}
-        rng = np.random.default_rng(random_state) if random_state is not None else None
+        rng = np.random.default_rng(random_state)
         n_steps = int(duration * (1 / dt))
         s = np.zeros(n_steps)
         v = np.zeros(n_steps)
@@ -64,18 +64,20 @@ class BenchmarkSystems:
 
         kappa, theta, sigma, rho = 2.0, 0.04, 0.2, -0.7
 
-        for i in range(1, n_steps):
-            if rng is None:
-                w_s = np.random.normal()
-                w_v = rho * w_s + np.sqrt(1 - rho**2) * np.random.normal()
-            else:
-                w_s = rng.normal()
-                w_v = rho * w_s + np.sqrt(1 - rho**2) * rng.normal()
+        # Pre-draw the correlated Brownian increments; only the state recursion
+        # needs to stay sequential.
+        w_s = rng.normal(size=n_steps - 1)
+        w_v = rho * w_s + np.sqrt(1 - rho**2) * rng.normal(size=n_steps - 1)
 
-            s[i] = s[i - 1] * np.exp((0.05 - 0.5 * v[i - 1]) * dt + np.sqrt(v[i - 1] * dt) * w_s)
+        for i in range(1, n_steps):
+            s[i] = s[i - 1] * np.exp(
+                (0.05 - 0.5 * v[i - 1]) * dt + np.sqrt(v[i - 1] * dt) * w_s[i - 1]
+            )
             v[i] = np.maximum(
                 0,
-                v[i - 1] + kappa * (theta - v[i - 1]) * dt + sigma * np.sqrt(v[i - 1] * dt) * w_v,
+                v[i - 1]
+                + kappa * (theta - v[i - 1]) * dt
+                + sigma * np.sqrt(v[i - 1] * dt) * w_v[i - 1],
             )
 
         t = np.linspace(0, duration, n_steps)

--- a/src/drr_framework/modules.py
+++ b/src/drr_framework/modules.py
@@ -95,8 +95,10 @@ class ResonanceDetector:
     ) -> dict:
         """Detect dominant resonance structure in one time series.
 
-        Supported methods are ``fft``, ``welch``, and ``markov``. ``wavelet`` is
-        reserved as an explicit not-yet-implemented research surface.
+        Supported methods are ``fft``, ``welch``, ``wavelet``, and ``markov``.
+        The ``wavelet`` method uses a Morlet continuous wavelet transform and
+        additionally returns a time-frequency ``scalogram`` for nonstationary
+        signals.
         """
 
         data = np.asarray(data, dtype=float)
@@ -110,7 +112,7 @@ class ResonanceDetector:
         if method == "welch":
             return self._detect_with_welch(data, sampling_rate, peak_height_ratio)
         if method == "wavelet":
-            return self._detect_with_wavelet(data)
+            return self._detect_with_wavelet(data, sampling_rate, peak_height_ratio)
         if method == "markov":
             return self._detect_with_markov(data, n_clusters)
         raise ValueError(f"Unknown resonance detection method: {method}")
@@ -196,11 +198,108 @@ class ResonanceDetector:
             "spectrum": psd,
         }
 
-    def _detect_with_wavelet(self, data: np.ndarray) -> dict:
-        raise NotImplementedError(
-            "Wavelet resonance detection is not implemented yet. "
-            "Use method='fft', method='welch', or method='markov'."
-        )
+    def _detect_with_wavelet(
+        self,
+        data: np.ndarray,
+        sampling_rate: float,
+        peak_height_ratio: float,
+        n_frequencies: int = 96,
+        omega0: float = 6.0,
+    ) -> dict:
+        """Detect resonances with a Morlet continuous wavelet transform.
+
+        The scalogram is computed by FFT-based convolution against
+        L1-normalized analytic Morlet wavelets, so a sinusoid produces the same
+        response magnitude at every frequency. The time-averaged scalogram
+        (the global wavelet spectrum) is then searched for peaks exactly like
+        the FFT/Welch paths, which keeps the return schema consistent. Unlike
+        those paths, the full ``scalogram`` is also returned (when small enough
+        to hold in memory), exposing when each resonance is active.
+        """
+        if sampling_rate <= 0:
+            raise ValueError("sampling_rate must be positive")
+        if not 0 < peak_height_ratio <= 1:
+            raise ValueError("peak_height_ratio must be in the interval (0, 1]")
+
+        n = len(data)
+        # Require roughly two full cycles of the slowest resolvable frequency.
+        min_frequency = 2.0 * sampling_rate / n if n else 0.0
+        max_frequency = sampling_rate / 2.0
+        if n < 16 or min_frequency >= max_frequency:
+            return self._detect_with_fft(data, sampling_rate, peak_height_ratio)
+
+        centered = data - np.mean(data)
+        frequencies = np.geomspace(min_frequency, max_frequency, n_frequencies)
+        scales = omega0 / (2.0 * np.pi * frequencies)
+
+        angular = 2.0 * np.pi * np.fft.fftfreq(n, d=1.0 / sampling_rate)
+        analytic_mask = angular > 0
+        data_hat = np.fft.fft(centered)
+
+        keep_scalogram = n * n_frequencies <= 8_000_000
+        scalogram = np.empty((n_frequencies, n)) if keep_scalogram else None
+        global_spectrum = np.empty(n_frequencies)
+
+        # Chunk over scales so the (chunk, n) wavelet window stays bounded in memory.
+        chunk = max(1, 4_000_000 // n)
+        for start in range(0, n_frequencies, chunk):
+            stop = min(start + chunk, n_frequencies)
+            window = np.exp(-0.5 * (scales[start:stop, None] * angular[None, :] - omega0) ** 2)
+            window *= analytic_mask[None, :]
+            power = np.abs(np.fft.ifft(data_hat[None, :] * window, axis=1)) ** 2
+            global_spectrum[start:stop] = power.mean(axis=1)
+            if scalogram is not None:
+                scalogram[start:stop] = power
+
+        max_power = float(np.max(global_spectrum)) if global_spectrum.size else 0.0
+        peaks, _ = find_peaks(global_spectrum, height=max_power * peak_height_ratio)
+
+        dominant_freq = self._refine_wavelet_peaks(frequencies, global_spectrum, peaks)
+        peak_power = global_spectrum[peaks]
+        if len(peak_power) > 0:
+            order = np.argsort(peak_power)[::-1]
+            dominant_freq = dominant_freq[order]
+            peak_power = peak_power[order]
+
+        noise_floor = float(np.median(global_spectrum)) if global_spectrum.size else 0.0
+
+        return {
+            "method": "wavelet",
+            "dominant_freq": dominant_freq,
+            "peak_magnitude": peak_power,
+            "confidence": _peak_confidence(peak_power, noise_floor),
+            "noise_floor": noise_floor,
+            "frequency_axis": frequencies,
+            "spectrum": global_spectrum,
+            "scalogram": scalogram,
+            "time_axis": np.arange(n) / sampling_rate,
+        }
+
+    @staticmethod
+    def _refine_wavelet_peaks(
+        frequencies: np.ndarray, spectrum: np.ndarray, peaks: np.ndarray
+    ) -> np.ndarray:
+        """Refine peak frequencies with a parabolic fit in log-frequency space.
+
+        The wavelet frequency grid is geometric, so interior peaks are sharpened
+        by fitting a parabola through the peak and its neighbors and shifting the
+        estimate by the vertex offset (clamped to half a grid step).
+        """
+        refined = frequencies[peaks].astype(float)
+        if len(peaks) == 0 or len(frequencies) < 2:
+            return refined
+
+        log_step = float(np.log(frequencies[1]) - np.log(frequencies[0]))
+        for i, peak in enumerate(peaks):
+            if peak <= 0 or peak >= len(spectrum) - 1:
+                continue
+            left, center, right = spectrum[peak - 1], spectrum[peak], spectrum[peak + 1]
+            curvature = left - 2.0 * center + right
+            if abs(curvature) <= _EPS:
+                continue
+            offset = float(np.clip(0.5 * (left - right) / curvature, -0.5, 0.5))
+            refined[i] = float(np.exp(np.log(frequencies[peak]) + offset * log_step))
+        return refined
 
     def _detect_with_markov(self, data: np.ndarray, n_clusters: int) -> dict:
         if not SKLEARN_AVAILABLE:

--- a/src/drr_framework/realtime.py
+++ b/src/drr_framework/realtime.py
@@ -16,7 +16,13 @@ class RealTimeDRR:
     repeated np.array() conversions on every analysis call.
     """
 
-    def __init__(self, window_size: int, n_variables: int = 1, threshold: float = 0.5):
+    def __init__(
+        self,
+        window_size: int,
+        n_variables: int = 1,
+        threshold: float = 0.5,
+        analysis_interval: int = 1,
+    ):
         """
         Initializes the real-time DRR analyzer.
 
@@ -24,6 +30,10 @@ class RealTimeDRR:
             window_size (int): The size of the sliding window.
             n_variables (int): The number of variables in the time series.
             threshold (float): The anomaly detection threshold.
+            analysis_interval (int): Run the full analysis every N-th point
+                once the window is full. The default of 1 analyzes every point;
+                larger values trade update latency for throughput on
+                high-frequency streams.
         """
         if window_size <= 0:
             raise ValueError("window_size must be a positive integer")
@@ -31,9 +41,12 @@ class RealTimeDRR:
             raise ValueError("n_variables must be a positive integer")
         if not 0 <= threshold <= 1:
             raise ValueError("threshold must be between 0 and 1")
+        if analysis_interval <= 0:
+            raise ValueError("analysis_interval must be a positive integer")
 
         self.window_size = window_size
         self.n_variables = n_variables
+        self.analysis_interval = analysis_interval
         self._buffer = np.empty((window_size, n_variables), dtype=np.float64)
         self._count = 0  # total points inserted
         self.resonance_detector = ResonanceDetector()
@@ -49,7 +62,8 @@ class RealTimeDRR:
 
         Returns:
             A list with one result dict per variable (resonances, depth, anomaly
-            flag) once the window is full, otherwise ``None``.
+            flag) once the window is full and the point lands on the configured
+            ``analysis_interval``, otherwise ``None``.
         """
         # Handle scalar input for single variable case
         if np.isscalar(data_point):
@@ -68,7 +82,10 @@ class RealTimeDRR:
         self._buffer[idx] = data_point
         self._count += 1
 
-        if self._count >= self.window_size:
+        if (
+            self._count >= self.window_size
+            and (self._count - self.window_size) % self.analysis_interval == 0
+        ):
             # Build the ordered view from the ring buffer
             start = self._count % self.window_size
             data_array: np.ndarray

--- a/tests/test_drr_framework.py
+++ b/tests/test_drr_framework.py
@@ -50,11 +50,13 @@ def test_markov_detector_validates_cluster_configuration():
         detector.detect(np.random.rand(3), method="markov", n_clusters=4)
 
 
-def test_wavelet_detector_raises_not_implemented():
+def test_wavelet_detector_returns_standard_schema():
     detector = ResonanceDetector()
+    result = detector.detect(np.random.rand(64), method="wavelet", sampling_rate=100)
 
-    with pytest.raises(NotImplementedError, match="not implemented"):
-        detector.detect(np.random.rand(50), method="wavelet")
+    assert result["method"] == "wavelet"
+    for key in ("dominant_freq", "peak_magnitude", "confidence", "spectrum", "scalogram"):
+        assert key in result
 
 
 def test_rooting_analyzer():
@@ -205,6 +207,32 @@ def test_real_time_drr_rejects_invalid_configuration():
     with pytest.raises(ValueError, match="threshold"):
         RealTimeDRR(window_size=5, n_variables=1, threshold=1.5)
 
+    with pytest.raises(ValueError, match="analysis_interval"):
+        RealTimeDRR(window_size=5, n_variables=1, analysis_interval=0)
+
+
+def test_real_time_drr_analysis_interval_throttles_updates():
+    """
+    With analysis_interval=3 and window_size=5, results should come back on
+    points 5, 8, and 11 only.
+    """
+    rt_drr = RealTimeDRR(window_size=5, n_variables=1, analysis_interval=3)
+
+    analyzed_points = [
+        i for i in range(1, 12) if rt_drr.process_data_point(np.random.rand()) is not None
+    ]
+    assert analyzed_points == [5, 8, 11]
+
+
+def test_heston_benchmark_is_reproducible_with_seed():
+    t1, data1 = BenchmarkSystems.generate_heston_data(duration=1, dt=1 / 50, random_state=42)
+    t2, data2 = BenchmarkSystems.generate_heston_data(duration=1, dt=1 / 50, random_state=42)
+
+    assert data1.shape == (50, 2)
+    np.testing.assert_allclose(data1, data2)
+    assert np.all(data1[:, 0] > 0)  # prices stay positive
+    assert np.all(data1[:, 1] >= 0)  # variance stays non-negative
+
 
 def test_drr_framework_rejects_invalid_configuration():
     from drr_framework.analysis import DynamicResonanceRooting
@@ -235,6 +263,33 @@ def test_analyze_system_is_deterministic_across_repeated_calls():
 
     assert first["agent_belief"] == second["agent_belief"]
     assert first["is_rooted"] == second["is_rooted"]
+
+
+def test_analyze_system_passes_spectral_method_through():
+    """
+    The spectral method selected in analyze_system must reach the detector
+    instead of silently falling back to FFT.
+    """
+    from drr_framework.analysis import DynamicResonanceRooting
+
+    sampling_rate = 100.0
+    t = np.linspace(0, 10, 1000, endpoint=False)
+    data = np.sin(2 * np.pi * 5 * t)
+
+    drr = DynamicResonanceRooting(embedding_dim=3, tau=2, sampling_rate=sampling_rate)
+
+    seen_methods = []
+    original_detect = drr.resonance_detector.detect
+
+    def spying_detect(*args, **kwargs):
+        seen_methods.append(kwargs.get("method"))
+        return original_detect(*args, **kwargs)
+
+    drr.resonance_detector.detect = spying_detect
+    results = drr.analyze_system(data, window_size=128, method="welch")
+
+    assert seen_methods and set(seen_methods) == {"welch"}
+    assert np.isclose(results["resonances"]["dim_0"]["dominant_freq"], 5.0, atol=0.5)
 
 
 def test_analyze_system_propagates_errors():

--- a/tests/test_wavelet_detection.py
+++ b/tests/test_wavelet_detection.py
@@ -1,0 +1,73 @@
+"""Tests for Morlet-wavelet resonance detection."""
+
+import numpy as np
+import pytest
+
+from drr_framework.modules import ResonanceDetector
+
+
+def _closest(detected: np.ndarray, target: float) -> float:
+    assert len(detected) > 0
+    return float(detected[np.argmin(np.abs(detected - target))])
+
+
+def test_wavelet_detector_identifies_dominant_frequency():
+    sampling_rate = 100.0
+    t = np.arange(0, 4.0, 1.0 / sampling_rate)
+    rng = np.random.default_rng(0)
+    data = np.sin(2 * np.pi * 15.0 * t) + 0.1 * rng.normal(size=len(t))
+
+    result = ResonanceDetector().detect(data, method="wavelet", sampling_rate=sampling_rate)
+
+    assert result["method"] == "wavelet"
+    assert np.isclose(result["dominant_freq"][0], 15.0, rtol=0.05)
+    assert result["confidence"][0] > 0.5
+
+
+def test_wavelet_detector_resolves_nonstationary_content():
+    """A signal that switches frequency mid-record is the wavelet use case:
+    both tones must be detected, and the scalogram must localize them in time.
+    """
+    sampling_rate = 200.0
+    half = np.arange(0, 3.0, 1.0 / sampling_rate)
+    data = np.concatenate([np.sin(2 * np.pi * 8.0 * half), np.sin(2 * np.pi * 30.0 * half)])
+
+    result = ResonanceDetector().detect(data, method="wavelet", sampling_rate=sampling_rate)
+    detected = result["dominant_freq"]
+
+    assert np.isclose(_closest(detected, 8.0), 8.0, rtol=0.1)
+    assert np.isclose(_closest(detected, 30.0), 30.0, rtol=0.1)
+
+    # Time localization: the 8 Hz band should carry its power in the first
+    # half of the record and the 30 Hz band in the second half.
+    frequencies = result["frequency_axis"]
+    scalogram = result["scalogram"]
+    assert scalogram.shape == (len(frequencies), len(data))
+
+    mid = len(data) // 2
+    low_band = int(np.argmin(np.abs(frequencies - 8.0)))
+    high_band = int(np.argmin(np.abs(frequencies - 30.0)))
+    assert scalogram[low_band, :mid].mean() > 5 * scalogram[low_band, mid:].mean()
+    assert scalogram[high_band, mid:].mean() > 5 * scalogram[high_band, :mid].mean()
+
+
+def test_wavelet_detector_falls_back_to_fft_for_short_series():
+    result = ResonanceDetector().detect(np.random.rand(8), method="wavelet", sampling_rate=100.0)
+    assert result["method"] == "fft"
+
+
+def test_wavelet_detector_validates_inputs():
+    detector = ResonanceDetector()
+
+    with pytest.raises(ValueError, match="sampling_rate"):
+        detector.detect(np.random.rand(64), method="wavelet", sampling_rate=0)
+
+    with pytest.raises(ValueError, match="peak_height_ratio"):
+        detector.detect(
+            np.random.rand(64), method="wavelet", sampling_rate=100, peak_height_ratio=2.0
+        )
+
+
+def test_wavelet_detector_handles_constant_signal():
+    result = ResonanceDetector().detect(np.ones(128), method="wavelet", sampling_rate=100.0)
+    assert len(result["dominant_freq"]) == 0


### PR DESCRIPTION
# Summary

This PR implements Morlet continuous wavelet transform (CWT) resonance detection as a new spectral method, alongside several API improvements to make spectral method selection available throughout the analysis pipeline.

**Key additions:**
- `method="wavelet"` in `ResonanceDetector.detect()` performs FFT-based Morlet CWT with peak selection on the global wavelet spectrum
- Returns a `scalogram` (frequency × time power map) and `time_axis` to localize nonstationary resonances in time
- Parabolic peak refinement in log-frequency space for sharper frequency estimates
- Memory-bounded scalogram computation (omitted if result would exceed ~8 MB)
- Automatic fallback to FFT for signals too short to resolve meaningful frequencies

**API improvements:**
- `DynamicResonanceRooting.analyze_system()` now accepts `method` and `peak_height_ratio` parameters, enabling Welch or wavelet detection end-to-end instead of always using FFT
- `RealTimeDRR` accepts `analysis_interval` to throttle analysis on high-frequency streams (run full analysis every N-th point)
- `plot_results()` accepts `show=False` for headless/batch environments
- Version string now single-sourced from package metadata

**Fixes:**
- Heston benchmark now always uses `numpy.random.default_rng` with pre-drawn correlated shocks for reproducibility
- `RealTimeDRR.reset()` properly resets anomaly detector history
- `__version__` corrected from stale `0.2.0` to `4.2.0`

## Type Of Change

- [x] Behavior change or new method
- [x] Test improvement

## Scientific Scope

The wavelet method is a new spectral analysis technique that complements FFT and Welch by exposing time-frequency structure in nonstationary signals. The global wavelet spectrum (time-averaged power) is searched for peaks using the same threshold logic as FFT/Welch, maintaining consistency in the return schema. The scalogram enables visual inspection of when each resonance is active—critical for systems with time-varying dynamics.

Peak refinement via parabolic fitting in log-frequency space (where the geometric frequency grid is uniform) improves frequency estimates without changing the peak detection threshold or confidence calculation.

## Verification

- [x] `python -m pytest` — Added comprehensive wavelet detection tests (`test_wavelet_detection.py`) covering:
  - Dominant frequency identification in synthetic sinusoids
  - Nonstationary signal resolution (two tones at different times)
  - Scalogram time localization
  - Fallback to FFT for short series
  - Input validation (sampling_rate, peak_height_ratio)
  - Constant signal handling
  - Updated existing test to verify wavelet method returns standard schema
- [x] `python -m compileall src examples scripts tests` — All modules compile
- [x] `python -m ruff check .` — No linting issues
- [x] `python -m black --check .` — Code formatted
- [x] Documentation reviewed and updated (api.md, architecture.md, CHANGELOG.md, README.md)

## Notes For Reviewers

**Assumptions:**
- Morlet wavelet with ω₀=6.0 (default) provides good time-frequency resolution tradeoff
- Geometric frequency spacing (96 frequencies by default) is sufficient for most use cases
- Memory limit of ~8 MB for scalogram is reasonable for typical analysis windows

**Limitations:**
- Scalogram is omitted (None) for very long signals to avoid memory exhaustion; spectrum and peaks are still returned
- Wavelet method requires at least 16 samples and resolvable frequency range; shorter/degenerate signals fall back to FFT
- Peak refinement is clamped to ±0.5 grid steps to avoid extrapolation artifacts

**Follow-up work:**
- Visualization helpers for scalogram display (time-frequency heatmaps)
- Configurable Morlet ω₀ parameter for different resolution tradeoffs
- Adaptive frequency grid based on signal length and sampling rate

https://claude.ai/code/session_01WytJfhZ3LFgZjK4zmU3wJx